### PR TITLE
print primitives directly, without running util.inspect on them

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,6 +59,8 @@ if (component) {
 
 if (argv.json || argv.j) {
 	process.stdout.write(JSON.stringify(val) + '\n')
+} else if (typeof val === 'string') {
+	process.stdout.write(val + '\n')
 } else {
 	const stdoutIsATerminal = isatty(process.stdout.fd)
 	process.stdout.write(inspect(val, {

--- a/test.js
+++ b/test.js
@@ -51,6 +51,6 @@ exec.shell(bin + ` --json 'https://example.org/foo/bar' host`)
 
 exec.shell(bin + ` 'https://example.org/foo/bar' scheme`)
 .then((res) => {
-	assert.strictEqual(res.stdout, `'https'`)
+	assert.strictEqual(res.stdout, `https`)
 })
 .catch(showError)


### PR DESCRIPTION
When interoperating with a non-JSON speaking environment, the quote wrapping applied by `util.inspect` can be burdensome.

Borrowing from [`jq`'s](https://stedolan.github.io/jq) learnings, this PR seeks to add support for `--raw-output` (shorthand `-r`). When parsing and extraction results in a string value (eg: `host`), passing `-r` will result in the raw value being printed directly to `stdout` with a trailing line.

eg:
```sh
## before
❯ npx parse-url-cli 'https://example.org/foo/bar' host
'example.org'

## after
❯ npx parse-url-cli 'https://example.org/foo/bar' host -r
example.org
```

If _both_ `--json` and `--raw-output` are specified, `--raw-output` takes precedence over `--json`.

eg:
```sh
❯ npx parse-url-cli 'https://example.org/foo/bar' host -jr
example.org
```